### PR TITLE
Add support for non-portable mode

### DIFF
--- a/altsnap.c
+++ b/altsnap.c
@@ -442,15 +442,24 @@ int WINAPI tWinMain(HINSTANCE hInst, HINSTANCE hPrevInstance, TCHAR *params, int
     && GetEnvironmentVariable(TEXT("APPDATA"), NULL, 0)) {
         // .ini file is not in current directorry, and APPDATA exists
         // we should look for %APPDATA%\AltSnap\AltSnap.ini
-        GetEnvironmentVariable(TEXT("APPDATA"), inipath, ARR_SZ(inipath));
-        lstrcat_s(inipath, ARR_SZ(inipath), TEXT("\\AltSnap"));
-        if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(inipath)) {
-            CreateDirectory(inipath, NULL);
+        TCHAR userini[MAX_PATH];
+        GetEnvironmentVariable(TEXT("APPDATA"), userini, ARR_SZ(userini));
+        lstrcat_s(userini, ARR_SZ(userini), TEXT("\\AltSnap"));
+        if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(userini)) {
+            CreateDirectory(userini, NULL);
+            LOG("CreateDirectory(%S)", userini);
         }
-        lstrcat_s(inipath, ARR_SZ(inipath), TEXT("\\AltSnap.ini"));
-    }
-    MessageBox(NULL, inipath, NULL, 0);
+        // Full user ini name.
+        lstrcat_s(userini, ARR_SZ(userini), TEXT("\\AltSnap.ini"));
+        if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(userini)) {
+            // Copy AltSnap.dni (Default ini file) if no ini present
+            lstrcpy_s(&inipath[lstrlen(inipath)-3], 4, TEXT("dni"));
+            CopyFile(inipath, userini, FALSE); // AltSnap.dni -> AltSnap.ini
+            LOG("CopyFile(%S -> %S)", inipath, userini);
+        }
 
+        lstrcpy_s(inipath, ARR_SZ(inipath), userini);
+    }
     LOG("ini file: %S", inipath);
 
     // Read parameters on command line

--- a/altsnap.c
+++ b/altsnap.c
@@ -85,9 +85,9 @@ int HookSystem()
             return 1;
         }
     }
-    HWND (WINAPI *Load)(HWND) = (HWND (WINAPI *)(HWND))GetProcAddress(hinstDLL, LOAD_PROC);
+    HWND (WINAPI *Load)(HWND, const TCHAR *) = (HWND (WINAPI *)(HWND, const TCHAR*))GetProcAddress(hinstDLL, LOAD_PROC);
     if(Load) {
-        g_dllmsgHKhwnd = Load(g_hwnd);
+        g_dllmsgHKhwnd = Load(g_hwnd, inipath);
     }
 
     LOG("HOOKS.DLL Loaded");
@@ -438,6 +438,19 @@ int WINAPI tWinMain(HINSTANCE hInst, HINSTANCE hPrevInstance, TCHAR *params, int
     GetModuleFileName(NULL, inipath, ARR_SZ(inipath));
     inipath[MAX_PATH-1] = '\0';
     lstrcpy_s(&inipath[lstrlen(inipath)-3], 4, TEXT("ini"));
+    if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(inipath)
+    && GetEnvironmentVariable(TEXT("APPDATA"), NULL, 0)) {
+        // .ini file is not in current directorry, and APPDATA exists
+        // we should look for %APPDATA%\AltSnap\AltSnap.ini
+        GetEnvironmentVariable(TEXT("APPDATA"), inipath, ARR_SZ(inipath));
+        lstrcat_s(inipath, ARR_SZ(inipath), TEXT("\\AltSnap"));
+        if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(inipath)) {
+            CreateDirectory(inipath, NULL);
+        }
+        lstrcat_s(inipath, ARR_SZ(inipath), TEXT("\\AltSnap.ini"));
+    }
+    MessageBox(NULL, inipath, NULL, 0);
+
     LOG("ini file: %S", inipath);
 
     // Read parameters on command line

--- a/hooks.c
+++ b/hooks.c
@@ -6153,7 +6153,7 @@ static void readblacklist(const TCHAR *section, struct blacklist *blacklist, con
 }
 // Read all the blacklitsts
 #define blacklist_section_length 32767
-void readallblacklists(TCHAR *inipath)
+void readallblacklists(const TCHAR *inipath)
 {
     mem00(&BlkLst, sizeof(BlkLst));
 
@@ -6376,13 +6376,12 @@ static void freeallinputSequences(void)
 #ifdef __cplusplus
 extern "C"
 #endif
-__declspec(dllexport) HWND WINAPI Load(HWND mainhwnd)
+__declspec(dllexport) HWND WINAPI Load(HWND mainhwnd, const TCHAR inipath[AT_LEAST MAX_PATH])
 {
 #if defined(_MSC_VER) && _MSC_VER > 1300
 #pragma comment(linker, "/EXPORT:" __FUNCTION__ "=" __FUNCDNAME__)
 #endif
     // Load settings
-    TCHAR inipath[MAX_PATH];
     unsigned i;
     state.action = AC_NONE;
     state.shift = 0;
@@ -6405,8 +6404,8 @@ __declspec(dllexport) HWND WINAPI Load(HWND mainhwnd)
 
 
     // Get ini path
-    GetModuleFileName(NULL, inipath, ARR_SZ(inipath));
-    lstrcpy(&inipath[lstrlen(inipath)-3], TEXT("ini"));
+//    GetModuleFileName(NULL, inipath, ARR_SZ(inipath));
+//    lstrcpy(&inipath[lstrlen(inipath)-3], TEXT("ini"));
 
     TCHAR stk_inisection[1420], *inisection; // Stack buffer.
     size_t inisectionlen = 8192;

--- a/hooks.h
+++ b/hooks.h
@@ -15,7 +15,7 @@
 		#define UNLOAD_PROC "Unload"
 	#else
 		#define LOW_LEVEL_KB_PROC "_LowLevelKeyboardProc@12"
-		#define LOAD_PROC "_Load@4"
+		#define LOAD_PROC "_Load@8"
 		#define UNLOAD_PROC "_Unload@0"
 	#endif
 #endif


### PR DESCRIPTION
We need to look for `%APPDATA%\AltSnap\AltSnap.ini` when the .ini file is not present in the exe directorry.
Like this you just need to put the ini file into AltSnap's folder for portable mode and just rename it for non-portable mode.

This is the first step towards #538 