### PR TITLE
Fix crash caused by window with size 0

### DIFF
--- a/unfuck.h
+++ b/unfuck.h
@@ -1003,9 +1003,19 @@ static int IsWindowCloaked(HWND hwnd)
     return S_OK == DwmGetWindowAttributeL(hwnd, DWMWA_CLOAKED, &cloaked, sizeof(cloaked))
         && cloaked;
 }
+/* Some windows might have a size of 0x0 (e.g., a 'Setup' window in Windows 11
+ * that appears to be visible despite having no size). It is assumed that this
+ * is an issue specific to a system update window in Windows 11 (and maybe other
+ * versions as well), although this has not been confirmed.
+ */
+static BOOL HasWindowSizeZero(HWND hwnd)
+{
+    RECT rc;
+    return GetWindowRect(hwnd, &rc) && (rc.right == rc.left || rc.bottom == rc.top);
+}
 static BOOL IsVisible(HWND hwnd)
 {
-    return IsWindowVisible(hwnd) && !IsWindowCloaked(hwnd);
+    return IsWindowVisible(hwnd) && !IsWindowCloaked(hwnd) && !HasWindowSizeZero(hwnd);
 }
 
 /* Gets the original owner of hwnd.


### PR DESCRIPTION
This pull request addresses an issue where the "Focus Window" action in AltSnap causes the program to crash when a window with a size of 0 is present. Although the configuration dialog remains functional, windows can no longer be dragged. This PR introduces a fix for the problem.

I was unable to find a way to deliberately recreate the window with size 0. However, I encountered the same issue on two different PCs running Windows 11 (one of them a fresh installation). Below are the properties of the problematic window:

```shell
---------------------------
Debug Info
---------------------------
Window Rect: (top, left, bottom, right): 720, 1280, 720, 1280
Process name: Unknown
IsWindowVisible: TRUE
IsWindowCloaked: FALSE
EXSTYLE & WS_EX_NOACTIVATE: TRUE
EXSTYLE & WS_EX_TOOLWINDOW: FALSE
STYLE & WS_CAPTION: TRUE
EXSTYLE & WS_EX_APPWINDOW: FALSE
BorderlessFlag: FALSE
MenuShowEmptyLabelWin: FALSE
Window title: 'Setup'
Blacklisted (Bottommost): FALSE

=> IsAltTabAble Result: TRUE
```

My assumption is that this issue may be related to a system update window in Win11 (and maybe other versions as well), though this has not been confirmed.