### PR TITLE
Notify system of move/resize event start and end

### DIFF
--- a/hooks.c
+++ b/hooks.c
@@ -2663,8 +2663,9 @@ __declspec(dllexport) LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wP
             if (state.action || state.alt) {
                 enum action action = state.action;
                 HideTransWin();
-                // Send WM_EXITSIZEMOVE
+                // Send WM_EXITSIZEMOVE and EVENT_SYSTEM_MOVESIZEEND
                 SendSizeMove(WM_EXITSIZEMOVE);
+                NotifyWinEvent(EVENT_SYSTEM_MOVESIZEEND, state.hwnd, 0, 0);
 
                 state.alt = 0;
                 state.alt1 = 0;
@@ -4960,8 +4961,9 @@ static int init_movement_and_actions(POINT pt, HWND hwnd, enum action action, in
         UpdateCursor(pt);
         SetWindowTrans(state.hwnd);
 
-        // Send WM_ENTERSIZEMOVE
+        // Send WM_ENTERSIZEMOVE and EVENT_SYSTEM_MOVESIZESTART
         SendSizeMove(WM_ENTERSIZEMOVE);
+        NotifyWinEvent(EVENT_SYSTEM_MOVESIZESTART, state.hwnd, 0, 0);
     } else if(button == BT_WHEEL || button == BT_HWHEEL) {
         // Wheel actions, directly return here
         // because maybe the action will not be done
@@ -5102,8 +5104,9 @@ static void FinishMovement()
     }
 
     HideTransWin();
-    // Send WM_EXITSIZEMOVE
+    // Send WM_EXITSIZEMOVE and EVENT_SYSTEM_MOVESIZEEND
     SendSizeMove(WM_EXITSIZEMOVE);
+    NotifyWinEvent(EVENT_SYSTEM_MOVESIZEEND, state.hwnd, 0, 0);
 
     state.action = AC_NONE;
     state.moving = 0;


### PR DESCRIPTION
This sends a `NotifyWinEvent` to notify that the window has started/ended moving/resizing.

This should fix compatibility with Komorebi. With this change the movements and resizes are now picked up by komorebi correctly.
~Although there is still an issue with komorebi borders, since when moving they check if left mouse button is pressed to keep updating, but somehow AltSnap is preventing the left mouse down from being picked up by komorebi, it checks using `GetKeyState(VK_LBUTTON)` but this returns 0 for some reason. The borders update properly once you finish the move/resize though.~

~@RamonUnch Can you help me out here to understand why is the left mouse button not being picked up properly? Is it because AltSnap returns `1` on `LowLevelMouseProc` when starting a move/resize? Is there any way around it?~

I've made a PR on komorebi to fix this on their side. So that PR along with this one should make AltSnap and komorebi work really well together!

Fix #535 