### PR TITLE
Fix typos and improve clarity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ WHAT'S NEW
 Many new features can be seen in the option dialog box, however some of them are only available through editing the AltSnap.ini file (middle click on tyhe tray icon for this).
 
 # VirusTotal false positive
-You will see with the latest builds that there are some allerts, usually from SecureAge APEX sometime also from another vendor. Those are false positive and I stopped to contact the APEX team for every release becase it is a loss of time I would rather spend on improving the program.
-I already redued a lot the numberof false positive, simply by changing build flags and by switching to an older version of NSIS installer system. This is an indication of the impertinance of some modern antivirus solutions. Chocolatey considers that up to 5 positives on VirusTotal is not even suspicious.
+You will see with the latest builds that there are some alerts, usually from SecureAge APEX and sometimes from other vendors. Those are false positives, and I stopped contacting the APEX team for every release because it is a waste of time I would rather spend on improving the program.
+I already reduced the number of false positives significantly, simply by changing build flags and by switching to an older version of the NSIS installer system. This is an indication of the impertinence of some modern antivirus solutions. Chocolatey considers that up to five positives on VirusTotal is not even suspicious.
 
 # Build
 AltSnap builds with gcc, I use Mingw-w64 (for i686).


### PR DESCRIPTION
Corrected several typographical errors in README.md, including "allerts" to "alerts" and "becase" to "because". Improved overall readability and grammatical structure of the text.