### PR TITLE
fix: ERRORs and add a quality of life for both sch_off and sch_on batch scripts

### DIFF
--- a/sch_Off.bat
+++ b/sch_Off.bat
@@ -1,9 +1,45 @@
-@echo =============================================================================
-@echo = This batch will remove the AltSnap's Scheduled task!                      =
-@echo = If you do not want to continue, close the window or hit Ctrl+C            =
-@echo =============================================================================
-@echo Going to run command:
-@echo schtasks.exe /DELETE /TN "AltSnap" %1 %2 %3 %4 %5 %6 %7 %8 %9
-@pause
-schtasks.exe /DELETE /TN "AltSnap" %1 %2 %3 %4 %5 %6 %7 %8 %9
-@pause
+@echo off
+:: Check for elevation
+fsutil dirty query %systemdrive% >nul 2>&1
+if '%errorlevel%' NEQ '0' (
+    :: Not elevated, so relaunch using vbscript
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+    echo UAC.ShellExecute "cmd.exe", "/c ""%~f0"" %*", "", "runas", 1 >> "%temp%\getadmin.vbs"
+    "%temp%\getadmin.vbs"
+    del "%temp%\getadmin.vbs"
+    exit /b
+)
+
+setlocal
+
+:: =============================================================================
+:: = This batch will remove the AltSnap's Scheduled task!                      =
+:: = If you do not want to continue, close the window or hit Ctrl+C            =
+:: =============================================================================
+
+echo =============================================================================
+echo = This batch will remove the AltSnap's Scheduled task!                      =
+echo = If you do not want to continue, close the window or hit Ctrl+C            =
+echo =============================================================================
+
+echo.
+echo Going to run command:
+echo schtasks.exe /DELETE /TN "AltSnap" %1 %2 %3 %4 %5 %6 %7 %8 %9
+echo.
+
+set /p "choice=Are you sure you want to delete the AltSnap scheduled task? [Y/n]: "
+
+:: Handle empty input (user just pressed Enter) as "Y"
+if "%choice%"=="" (
+    set "choice=y"
+)
+
+if /i "%choice%" equ "y" (
+    echo Deleting the AltSnap scheduled task...
+    schtasks.exe /DELETE /TN "AltSnap" %1 %2 %3 %4 %5 %6 %7 %8 %9 /F
+) else (
+    echo Deletion cancelled.
+)
+
+pause
+exit /b 0


### PR DESCRIPTION
### What it does compared to the previous

* Ask to elevate the terminal when run non-elevated (for both).
* Check if AltSnap is found in %APPDATA%
  * Check if AltSnap.XML exists

### For schedule deletion

* Add "Y" as the default answer

### Preview

**Before** 

* ERROR: Access is denied (when running without admin access)
* ERROR: The system cannot find the file specified. (with admin access)

![ERROR-1](https://github.com/user-attachments/assets/6ebee2ee-5d29-4408-8001-64b1079e28bc)
![ERROR-2](https://github.com/user-attachments/assets/800336c8-56af-4fda-bd0b-eb4d36a87e23)

**After**

![sch_on](https://github.com/user-attachments/assets/f965f2c8-006d-4947-ae3e-af944fc5a907)
![sch_off](https://github.com/user-attachments/assets/55e36a8a-a840-4723-b2ce-89d191edc337)
