### PR TITLE
Add instructions for building on Windows on ARM.

### DIFF
--- a/BUILD_ARM64.md
+++ b/BUILD_ARM64.md
@@ -1,0 +1,58 @@
+# Building AltSnap for Windows ARM64 (WOA)
+
+## Docker Cross-Compilation (Recommended)
+
+This uses the `dockcross/windows-arm64` Docker image with LLVM 14 and MinGW-w64 toolchain.
+
+### Prerequisites
+
+Docker must be installed and running:
+```bash
+docker --version
+```
+
+### Building
+
+Build for ARM64 using Docker:
+```bash
+# Build everything
+make -f MakefileARM64Docker
+
+# Build just the executable
+make -f MakefileARM64Docker AltSnap.exe
+
+# Build just the DLL
+make -f MakefileARM64Docker hooks.dll
+
+# Clean build artifacts
+make -f MakefileARM64Docker clean
+```
+
+
+## Output
+
+The build produces:
+- `AltSnap.exe` - Main GUI executable for Windows ARM64
+- `hooks.dll` - Support library for Windows ARM64
+
+Both files are PE32+ executables targeting Aarch64 (ARM64) for MS Windows.
+
+## Compatibility
+
+- Windows 10 on ARM (version 1709+)
+- Windows 11 on ARM
+- ARM64 devices like Surface Pro X, ARM-based laptops, etc.
+
+## Build Details
+
+- **Toolchain:** LLVM 14/Clang with MinGW-w64 headers
+- **Architecture:** ARMv8-A (ARM64)
+- **Build time:** ~60 seconds (after initial image download)
+- **Docker image size:** ~600MB (downloaded once)
+
+## Troubleshooting
+
+If you get permission errors on the built files, they may be owned by root (from Docker). Fix with:
+```bash
+sudo chown $USER:$USER AltSnap.exe hooks.dll
+```

--- a/MakefileARM64Docker
+++ b/MakefileARM64Docker
@@ -1,0 +1,42 @@
+# Docker-based ARM64 Windows cross-compilation using dockcross
+DOCKER_IMAGE=dockcross/windows-arm64
+DOCKER_RUN=docker run --rm -v $(PWD):/work -w /work $(DOCKER_IMAGE)
+
+# These will be executed inside the container
+CC=aarch64-w64-mingw32-gcc
+WR=llvm-windres
+
+WARNINGS=-Wall -Wformat-security -Wstrict-overflow -Wsign-compare -Wclobbered \
+    -Wempty-body -Wignored-qualifiers -Wuninitialized -Wtype-limits -Woverride-init \
+    -Wlogical-op -Wno-multichar -Wno-attributes -Wduplicated-cond -Wduplicated-branches \
+    -Wnull-dereference -Wno-unused-function -Wshadow -Wstack-usage=4096 -pedantic -Wc++-compat
+
+CFLAGS=-Os -fno-stack-check -fno-stack-protector -fno-ident -fomit-frame-pointer -fmerge-all-constants \
+    -momit-leaf-frame-pointer -march=armv8-a -mtune=generic \
+    -D__USE_MINGW_ANSI_STDIO=0 -Wp,-D_FORTIFY_SOURCE=2 -fshort-enums\
+    $(WARNINGS) -fno-exceptions -fno-dwarf2-cfi-asm -fno-asynchronous-unwind-tables
+
+LDFLAGS=-lkernel32 -luser32 -lgdi32 -lwinmm
+
+EXELD = $(LDFLAGS) -lcomctl32 -ladvapi32 -lshell32
+
+default: AltSnap.exe hooks.dll
+
+hooks.dll : hooks.c hooks.h hooksr.o unfuck.h nanolibc.h zones.c snap.c
+	$(DOCKER_RUN) $(CC) -o hooks.dll hooks.c hooksr.o $(CFLAGS) $(LDFLAGS) -shared
+
+AltSnap.exe : altsnapr.o altsnap.c hooks.h tray.c config.c languages.h languages.c unfuck.h nanolibc.h
+	$(DOCKER_RUN) $(CC) -o AltSnap.exe altsnap.c altsnapr.o $(CFLAGS) $(EXELD) -mwindows -DtWinMain=wWinMain -municode
+
+altsnapr.o : altsnap.rc window.rc resource.h AltSnap.exe.manifest media/find.cur media/find.ico media/icon.ico media/tray-disabled.ico media/tray-enabled.ico
+	$(DOCKER_RUN) $(WR) altsnap.rc -o altsnapr.o --target=aarch64-w64-mingw32
+
+hooksr.o: hooks.rc
+	$(DOCKER_RUN) $(WR) hooks.rc -o hooksr.o --target=aarch64-w64-mingw32
+
+clean :
+	rm -f altsnapr.o AltSnap.exe hooksr.o hooks.dll
+
+# Helper target to get shell inside container for debugging
+shell:
+	$(DOCKER_RUN) bash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Just install the latest version (I use TDM-gcc 10.3, MinGW64 based) and use:
 
 `> make -fMakefileTCC` for i386 build using tcc, [Bellard's thiny c compiler](https://bellard.org/tcc/)
 
+`> make -fMakefileARM64Docker` for ARM64 Windows build using Docker (see [BUILD_ARM64.md](BUILD_ARM64.md))
+
 You can also use mk.bat and mk64.bat files.
 For Clang, I use LLVM5.0.1 with the headers and libs from Mingw-w64.
 Be sure to adjust your include and lib directorries on the command line with `-IPath\to\mingw\include` and `-LPath\to\mingw\lib`.


### PR DESCRIPTION
Mostly figured out via Claude. Tested on Windows 11 Pro 24H2 26100.4946.